### PR TITLE
gba-md5-readme

### DIFF
--- a/patches/GBA/README.md
+++ b/patches/GBA/README.md
@@ -1,0 +1,7 @@
+# GBA
+
+# MD5 Hashes
+The following are the resulting hashes after applying the patch file.
+
+Pokemon Quartz (RUBY USA,EUROPE) f392d6c0cf2cdb9a38afef822f96631c
+Pokemon Topaz(RUBY USA,EUROPE).bps  5fc130c06336cf69af9f7bd618dedcd5


### PR DESCRIPTION
Adding md5 hashes to the known resulting roms. It's oftentimes helpful to know that the patcher has correctly patched a rom.